### PR TITLE
Make `Players` behave as a Group

### DIFF
--- a/lib/Labyrinth/Players.hs
+++ b/lib/Labyrinth/Players.hs
@@ -17,7 +17,7 @@ import           Prelude hiding (lookup)
 import           Lens.Micro     ((^.))
 import           Lens.Micro.TH  (makeLenses)
 import           Data.Map       (Map)
-import qualified Data.Map       as Map
+import qualified Data.Map       as M
 
 type Name = String
 type PlayerStore = Map Color Player
@@ -36,14 +36,14 @@ instance Monoid Color where
   mempty = Clear
 
 instance Monoid Players where
-  mempty = Players Map.empty
+  mempty = Players M.empty
   Players l `mappend` Players r = Players (mergePlayers l r)
 
 invert :: Players -> Players
-invert (Players ps) = Players (Map.map (const PlayerRemoved) ps)
+invert (Players ps) = Players (M.map (const PlayerRemoved) ps)
 
 mergePlayers :: PlayerStore -> PlayerStore -> PlayerStore
-mergePlayers = Map.mergeWithKey merge id id
+mergePlayers = M.mergeWithKey merge id id
   where
     merge :: Color -> Player -> Player -> Maybe Player
     merge _ PlayerRemoved _             = Nothing
@@ -51,17 +51,17 @@ mergePlayers = Map.mergeWithKey merge id id
     merge _ _             p             = Just p
 
 fromPlayer :: Player -> Players
-fromPlayer p = Players (Map.insert  (p ^. color) p mempty)
+fromPlayer p = Players (M.insert  (p ^. color) p mempty)
 
 lookup :: Player -> Players -> Maybe Player
-lookup p (Players ps) = Map.lookup (p ^. color) ps
+lookup p (Players ps) = M.lookup (p ^. color) ps
 
 lookupByColor :: Color -> Players -> Maybe Player
-lookupByColor c (Players ps) = Map.lookup c ps
+lookupByColor c (Players ps) = M.lookup c ps
 
 next :: Player -> Players -> Maybe Player
 next current ps@(Players psMap)
-  | Map.size psMap < 2 = Nothing
+  | M.size psMap < 2 = Nothing
   | otherwise        = next' (current ^. color)
   where
     next' c = case (lookupByColor (nextColor c) ps) of

--- a/lib/Labyrinth/Players.hs
+++ b/lib/Labyrinth/Players.hs
@@ -40,14 +40,15 @@ instance Monoid Players where
   Players l `mappend` Players r = Players (mergePlayers l r)
 
 invert :: Players -> Players
-invert = id
+invert (Players ps) = Players (Map.map (const PlayerRemoved) ps)
 
 mergePlayers :: PlayerStore -> PlayerStore -> PlayerStore
-mergePlayers = Map.mergeWithKey merge' id id
+mergePlayers = Map.mergeWithKey merge id id
   where
-    merge' _ PlayerRemoved  _             = Nothing
-    merge' _ _              PlayerRemoved = Nothing
-    merge' _ _              p             = Just p
+    merge :: Color -> Player -> Player -> Maybe Player
+    merge _ PlayerRemoved _             = Nothing
+    merge _ _             PlayerRemoved = Nothing
+    merge _ _             p             = Just p
 
 fromPlayer :: Player -> Players
 fromPlayer p = Players (Map.insert  (p ^. color) p mempty)

--- a/lib/Labyrinth/Players.hs
+++ b/lib/Labyrinth/Players.hs
@@ -3,7 +3,7 @@ module Labyrinth.Players
     ( Name
     , Players (..)
     , Player (Player)
-    , Color (..)
+    , Color (Yellow, Blue, Green, Red)
     , color
     , name
     , next
@@ -19,15 +19,25 @@ import           Data.Map       (Map)
 import qualified Data.Map       as Map
 
 type Name = String
-data Color = Yellow | Blue | Green | Red deriving (Show, Eq, Ord)
+type PlayerStore = Map Color Player
+data Color = Clear | Yellow | Blue | Green | Red deriving (Show, Eq, Ord)
 
-data Players = Players (Map Color Player) deriving (Show, Eq)
+instance Monoid Color where
+  _ `mappend` r = r
+  mempty = Clear
+
+data Players = Players PlayerStore deriving (Show, Eq)
 
 instance Monoid Players where
-  Players l `mappend` Players r = Players (Map.union r l)
   mempty = Players Map.empty
+  Players l `mappend` Players r = Players (merge l r)
 
-data Player = Player
+merge :: PlayerStore -> PlayerStore -> PlayerStore
+merge = Map.mergeWithKey merge' id id
+  where
+    merge' _ _ r = Just r
+
+data Player = Pempty | Player
     { _color :: Color
     , _name  :: Name
     } deriving (Show, Eq)

--- a/lib/Labyrinth/Players.hs
+++ b/lib/Labyrinth/Players.hs
@@ -32,7 +32,7 @@ makeLenses ''Player
 data Players = Players PlayerStore deriving (Show, Eq)
 
 instance Monoid Color where
-  _ `mappend` r = r
+  _ `mappend` c = c
   mempty = Clear
 
 instance Monoid Players where

--- a/lib/Labyrinth/Players.hs
+++ b/lib/Labyrinth/Players.hs
@@ -2,7 +2,7 @@
 module Labyrinth.Players
     ( Name
     , Players (..)
-    , Player (..)
+    , Player (Player)
     , Color (..)
     , color
     , name
@@ -15,16 +15,17 @@ module Labyrinth.Players
 import           Prelude hiding (lookup)
 import           Lens.Micro     ((^.))
 import           Lens.Micro.TH  (makeLenses)
-import qualified Data.Map as M
+import           Data.Map       (Map)
+import qualified Data.Map       as Map
 
 type Name = String
 data Color = Yellow | Blue | Green | Red deriving (Show, Eq, Ord)
 
-data Players = Players (M.Map Color Player) deriving (Show, Eq)
+data Players = Players (Map Color Player) deriving (Show, Eq)
 
 instance Monoid Players where
-  Players l `mappend` Players r = Players (M.union r l)
-  mempty = Players M.empty
+  Players l `mappend` Players r = Players (Map.union r l)
+  mempty = Players Map.empty
 
 data Player = Player
     { _color :: Color
@@ -33,17 +34,17 @@ data Player = Player
 makeLenses ''Player
 
 fromPlayer :: Player -> Players
-fromPlayer p = Players (M.insert  (p ^. color) p mempty)
+fromPlayer p = Players (Map.insert  (p ^. color) p mempty)
 
 lookup :: Player -> Players -> Maybe Player
-lookup p (Players ps) = M.lookup (p ^. color) ps
+lookup p (Players ps) = Map.lookup (p ^. color) ps
 
 lookupByColor :: Color -> Players -> Maybe Player
-lookupByColor c (Players ps) = M.lookup c ps
+lookupByColor c (Players ps) = Map.lookup c ps
 
 next :: Player -> Players -> Maybe Player
 next current ps@(Players psMap)
-  | M.size psMap < 2 = Nothing
+  | Map.size psMap < 2 = Nothing
   | otherwise        = next' (current ^. color)
   where
     next' c = case (lookupByColor (nextColor c) ps) of

--- a/test/Test/Labyrinth/PlayersSpec.hs
+++ b/test/Test/Labyrinth/PlayersSpec.hs
@@ -66,3 +66,20 @@ spec = do
 
       it "yellow should follow red" $
         Players.next red players `shouldBe` Just yellow
+
+  describe "Inverted players" $ do
+    it "should be used to remove players" $ do
+      let yellow    = Player Yellow "yellow"
+          blue      = Player Blue "blue"
+          green     = Player Green "green"
+          red       = Player Red "red"
+          players   = Players.fromPlayer yellow <>
+                      Players.fromPlayer blue   <>
+                      Players.fromPlayer green  <>
+                      Players.fromPlayer red
+          remove    = Players.fromPlayer blue   <>
+                      Players.fromPlayer green
+          expected  = Players.fromPlayer yellow <>
+                      Players.fromPlayer red
+      players <> (Players.invert remove) `shouldBe` expected
+

--- a/test/Test/Labyrinth/PlayersSpec.hs
+++ b/test/Test/Labyrinth/PlayersSpec.hs
@@ -67,7 +67,7 @@ spec = do
       it "yellow should follow red" $
         Players.next red players `shouldBe` Just yellow
 
-  describe "Inverted players" $ do
+  describe "Inverted `Players`" $ do
     it "should be used to remove players" $ do
       let yellow    = Player Yellow "yellow"
           blue      = Player Blue "blue"


### PR DESCRIPTION
... even when there is no Group typeclass in base. Mainly to experiment with the idea of removing players abstractly.

Not sure if worth keeping, but implementing it was fun and not too hard actually.